### PR TITLE
[feat] add export button to attendance datagrids

### DIFF
--- a/webapp/src/components/exportDataButton/ExportDataButton.tsx
+++ b/webapp/src/components/exportDataButton/ExportDataButton.tsx
@@ -1,11 +1,11 @@
-import { gridClasses, GridToolbarContainer, GridToolbarExport } from "@mui/x-data-grid";
-import React, { ReactElement } from "react";
+import { gridClasses, GridToolbarContainer, GridToolbarExport } from '@mui/x-data-grid';
+import React, { ReactElement } from 'react';
 
 const ExportDataButton = (): ReactElement => (
   <GridToolbarContainer className={gridClasses.toolbarContainer}>
     <GridToolbarExport
       printOptions={{
-        allColumns: true
+        allColumns: true,
       }}
     />
   </GridToolbarContainer>

--- a/webapp/src/components/exportDataButton/ExportDataButton.tsx
+++ b/webapp/src/components/exportDataButton/ExportDataButton.tsx
@@ -1,0 +1,14 @@
+import { gridClasses, GridToolbarContainer, GridToolbarExport } from "@mui/x-data-grid";
+import React, { ReactElement } from "react";
+
+const ExportDataButton = (): ReactElement => (
+  <GridToolbarContainer className={gridClasses.toolbarContainer}>
+    <GridToolbarExport
+      printOptions={{
+        allColumns: true
+      }}
+    />
+  </GridToolbarContainer>
+);
+
+export default ExportDataButton;

--- a/webapp/src/components/lectureView/LectureAttendanceList.tsx
+++ b/webapp/src/components/lectureView/LectureAttendanceList.tsx
@@ -5,6 +5,7 @@ import { getAttendanceByEventID } from '../../api/Api';
 import { getAzureUser } from '../../api/GraphApi';
 import { Lecture } from '../../lib/Types';
 import { colors } from '../../theme/Theme';
+import ExportDataButton from "../exportDataButton/ExportDataButton";
 
 interface LectureAttendanceListProps {
   lecture: Lecture;
@@ -57,6 +58,9 @@ const LectureAttendanceList = ({ lecture }: LectureAttendanceListProps): ReactEl
         '& .MuiDataGrid-virtualScrollerRenderZone': {
           backgroundColor: colors.white,
         },
+      }}
+      components={{
+        Toolbar: ExportDataButton,
       }}
       autoHeight
       rowHeight={20}

--- a/webapp/src/components/lectureView/LectureAttendanceList.tsx
+++ b/webapp/src/components/lectureView/LectureAttendanceList.tsx
@@ -5,7 +5,7 @@ import { getAttendanceByEventID } from '../../api/Api';
 import { getAzureUser } from '../../api/GraphApi';
 import { Lecture } from '../../lib/Types';
 import { colors } from '../../theme/Theme';
-import ExportDataButton from "../exportDataButton/ExportDataButton";
+import ExportDataButton from '../exportDataButton/ExportDataButton';
 
 interface LectureAttendanceListProps {
   lecture: Lecture;

--- a/webapp/src/section/eventPlanner/Attendance.tsx
+++ b/webapp/src/section/eventPlanner/Attendance.tsx
@@ -96,7 +96,7 @@ const Attendance = ({ event, lectures }: AttendanceProps): ReactElement => {
               remote: attendant.remote ? 'Ja' : 'Nej',
               message: attendant.message || '-',
               allLectures,
-              lectures: allLectures.map((lectureData) => lectureData.lecture.title).join(' '),
+              lectures: allLectures.map((lectureData) => lectureData.lecture.title).join('; '),
             };
           })
         );

--- a/webapp/src/section/eventPlanner/Attendance.tsx
+++ b/webapp/src/section/eventPlanner/Attendance.tsx
@@ -4,11 +4,11 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 import { getAttendanceByEventID } from '../../api/Api';
 import { getAzureUser } from '../../api/GraphApi';
+import ExportDataButton from '../../components/exportDataButton/ExportDataButton';
 import SmallLoader from '../../components/loader/SmallLoader';
 import { useAppSelector } from '../../lib/Lib';
 import { Event, Lecture } from '../../lib/Types';
 import { colors, padding } from '../../theme/Theme';
-import ExportDataButton from "../../components/exportDataButton/ExportDataButton";
 
 interface LectureRow {
   color: string;

--- a/webapp/src/section/eventPlanner/Attendance.tsx
+++ b/webapp/src/section/eventPlanner/Attendance.tsx
@@ -8,6 +8,7 @@ import SmallLoader from '../../components/loader/SmallLoader';
 import { useAppSelector } from '../../lib/Lib';
 import { Event, Lecture } from '../../lib/Types';
 import { colors, padding } from '../../theme/Theme';
+import ExportDataButton from "../../components/exportDataButton/ExportDataButton";
 
 interface LectureRow {
   color: string;
@@ -126,6 +127,9 @@ const Attendance = ({ event, lectures }: AttendanceProps): ReactElement => {
         '& .MuiDataGrid-virtualScrollerRenderZone': {
           backgroundColor: colors.white,
         },
+      }}
+      components={{
+        Toolbar: ExportDataButton,
       }}
       rowHeight={200}
       rows={rows}


### PR DESCRIPTION
This commit will make it possible for both admins and speakers to export the attendance lists as a csv