### PR TITLE
Remove options to sort ideas from opkoko view

### DIFF
--- a/webapp/src/components/filter/Filter.tsx
+++ b/webapp/src/components/filter/Filter.tsx
@@ -7,7 +7,7 @@ import {
   MenuItem,
   Select,
   SxProps,
-  TextField,
+  TextField
 } from '@mui/material';
 import { ReactElement, useEffect, useState } from 'react';
 import { Lecture } from '../../lib/Types';
@@ -16,11 +16,12 @@ import LectureIdea from '../lecture/Lecture';
 
 const formControlStyle: SxProps = {
   marginBottom: padding.standard,
-  minWidth: 120,
+  minWidth: 120
 };
 
 interface FilterProps {
   lectures: Lecture[];
+  opkoko?: boolean;
 }
 
 // Sort the "Sortera" - dropdown
@@ -56,13 +57,13 @@ const handleSearch = (value: string, filtered: Lecture[]): Lecture[] => {
   });
 };
 
-const Filter = ({ lectures }: FilterProps): ReactElement => {
+const Filter = ({ lectures, opkoko }: FilterProps): ReactElement => {
   const [filteredLectures, setLectures] = useState(lectures);
 
   const [options, setOptions] = useState({
     sort: '',
     filter: '',
-    search: '',
+    search: ''
   });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,37 +86,41 @@ const Filter = ({ lectures }: FilterProps): ReactElement => {
           gridAutoFlow: 'column',
           alignItems: 'top',
           gridTemplateColumns: 'initial initial auto',
-          columnGap: padding.standard,
+          columnGap: padding.standard
         }}
       >
-        <FormControl variant="filled" sx={formControlStyle}>
-          <InputLabel shrink>Sortera</InputLabel>
-          <Select
-            value={options.sort}
-            name="sort"
-            onChange={(e) => handleOptions(e)}
-            autoWidth
-            displayEmpty
-          >
-            <MenuItem value="">&nbsp;</MenuItem>
-            <MenuItem value="new">Nyast först</MenuItem>
-            <MenuItem value="old">Äldst först</MenuItem>
-          </Select>
-        </FormControl>
-        <FormControl variant="filled" sx={formControlStyle}>
-          <InputLabel shrink>Filter</InputLabel>
-          <Select
-            value={options.filter}
-            name="filter"
-            onChange={(e) => handleOptions(e)}
-            autoWidth
-            displayEmpty
-          >
-            <MenuItem value="">&nbsp;</MenuItem>
-            <MenuItem value="null">Öppen idé</MenuItem>
-            <MenuItem value="lecturer">Söker feedback</MenuItem>
-          </Select>
-        </FormControl>
+        {!opkoko && (
+          <>
+            <FormControl variant="filled" sx={formControlStyle}>
+              <InputLabel shrink>Sortera</InputLabel>
+              <Select
+                value={options.sort}
+                name="sort"
+                onChange={(e) => handleOptions(e)}
+                autoWidth
+                displayEmpty
+              >
+                <MenuItem value="">&nbsp;</MenuItem>
+                <MenuItem value="new">Nyast först</MenuItem>
+                <MenuItem value="old">Äldst först</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl variant="filled" sx={formControlStyle}>
+              <InputLabel shrink>Filter</InputLabel>
+              <Select
+                value={options.filter}
+                name="filter"
+                onChange={(e) => handleOptions(e)}
+                autoWidth
+                displayEmpty
+              >
+                <MenuItem value="">&nbsp;</MenuItem>
+                <MenuItem value="null">Öppen idé</MenuItem>
+                <MenuItem value="lecturer">Söker feedback</MenuItem>
+              </Select>
+            </FormControl>
+          </>
+        )}
         <TextField
           sx={formControlStyle}
           value={options.search}
@@ -128,7 +133,7 @@ const Filter = ({ lectures }: FilterProps): ReactElement => {
               <InputAdornment position="end">
                 <Search />
               </InputAdornment>
-            ),
+            )
           }}
         />
       </Box>
@@ -137,7 +142,7 @@ const Filter = ({ lectures }: FilterProps): ReactElement => {
         sx={{
           display: 'grid',
           gridGap: padding.standard,
-          alignContent: 'start',
+          alignContent: 'start'
         }}
       >
         {filteredLectures.map((lecture) => (

--- a/webapp/src/components/filter/Filter.tsx
+++ b/webapp/src/components/filter/Filter.tsx
@@ -7,7 +7,7 @@ import {
   MenuItem,
   Select,
   SxProps,
-  TextField
+  TextField,
 } from '@mui/material';
 import { ReactElement, useEffect, useState } from 'react';
 import { Lecture } from '../../lib/Types';
@@ -16,7 +16,7 @@ import LectureIdea from '../lecture/Lecture';
 
 const formControlStyle: SxProps = {
   marginBottom: padding.standard,
-  minWidth: 120
+  minWidth: 120,
 };
 
 interface FilterProps {
@@ -63,7 +63,7 @@ const Filter = ({ lectures, opkoko }: FilterProps): ReactElement => {
   const [options, setOptions] = useState({
     sort: '',
     filter: '',
-    search: ''
+    search: '',
   });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -86,7 +86,7 @@ const Filter = ({ lectures, opkoko }: FilterProps): ReactElement => {
           gridAutoFlow: 'column',
           alignItems: 'top',
           gridTemplateColumns: 'initial initial auto',
-          columnGap: padding.standard
+          columnGap: padding.standard,
         }}
       >
         {!opkoko && (
@@ -133,7 +133,7 @@ const Filter = ({ lectures, opkoko }: FilterProps): ReactElement => {
               <InputAdornment position="end">
                 <Search />
               </InputAdornment>
-            )
+            ),
           }}
         />
       </Box>
@@ -142,7 +142,7 @@ const Filter = ({ lectures, opkoko }: FilterProps): ReactElement => {
         sx={{
           display: 'grid',
           gridGap: padding.standard,
-          alignContent: 'start'
+          alignContent: 'start',
         }}
       >
         {filteredLectures.map((lecture) => (

--- a/webapp/src/section/home/HomeOPKoKo.tsx
+++ b/webapp/src/section/home/HomeOPKoKo.tsx
@@ -64,7 +64,7 @@ const HomeOPKoKo = (): ReactElement => {
         sx={{
           display: 'grid',
           gridGap: padding.standard,
-          alignContent: 'start'
+          alignContent: 'start',
         }}
       >
         {active && <PublishIdea cancel={off} opkoko />}
@@ -94,7 +94,7 @@ const HomeOPKoKo = (): ReactElement => {
               display: 'grid',
               justifyContent: 'center',
               alignContent: 'center',
-              minHeight: '300px'
+              minHeight: '300px',
             }}
           >
             <Typography variant="h5">Här var det tomt.</Typography>

--- a/webapp/src/section/home/HomeOPKoKo.tsx
+++ b/webapp/src/section/home/HomeOPKoKo.tsx
@@ -64,7 +64,7 @@ const HomeOPKoKo = (): ReactElement => {
         sx={{
           display: 'grid',
           gridGap: padding.standard,
-          alignContent: 'start',
+          alignContent: 'start'
         }}
       >
         {active && <PublishIdea cancel={off} opkoko />}
@@ -87,14 +87,14 @@ const HomeOPKoKo = (): ReactElement => {
           </>
         )}
         {lectureIdeas?.length ? (
-          <Filter lectures={lectureIdeas} />
+          <Filter opkoko lectures={lectureIdeas} />
         ) : (
           <Box
             sx={{
               display: 'grid',
               justifyContent: 'center',
               alignContent: 'center',
-              minHeight: '300px',
+              minHeight: '300px'
             }}
           >
             <Typography variant="h5">Här var det tomt.</Typography>


### PR DESCRIPTION
It was a bit ugly to have the options to filter in the idea-view for OPKoKo because there was only one type of ideas visible in this view. Therefore removed the filter-boxes altogether.